### PR TITLE
fix: style for Unraid 7.2

### DIFF
--- a/src/usr/local/emhttp/plugins/open.files/assets/style.css
+++ b/src/usr/local/emhttp/plugins/open.files/assets/style.css
@@ -29,10 +29,6 @@ div.flatpickr-calendar {
     font-size: 1.2rem;
 }
 
-div.dtcc-dropdown * {
-    color: black
-}
-
 span.dtcc-button-icon svg {
     color: white;
     background-color: gray;
@@ -50,4 +46,8 @@ input.flatpickr-input {
 .overflow-anywhere {
     overflow-wrap: anywhere;
     white-space: normal;
+}
+
+div.dt-length {
+    white-space: pre;
 }

--- a/src/usr/local/emhttp/plugins/open.files/include/Pages/OpenFiles.php
+++ b/src/usr/local/emhttp/plugins/open.files/include/Pages/OpenFiles.php
@@ -27,6 +27,11 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
+// Fix for black theme in Unraid 7.1 and earlier
+$vars = parse_ini_file('/usr/local/emhttp/state/var.ini');
+if (version_compare($vars['version'] ?? "", '7.1', '<=')) {
+    echo "<style>div.dtcc-dropdown * { color: black }</style>";
+}
 ?>
 <script src="/plugins/open.files/assets/translate.js"></script>
 <script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue with dropdown text color on Unraid versions 7.1 and earlier when using the black theme.
  * Corrected a minor CSS syntax error affecting text overflow handling.
  * Improved table display by ensuring whitespace is preserved in certain elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->